### PR TITLE
kubectl: Update url to reduce false positive with virustotal

### DIFF
--- a/bucket/kubectl.json
+++ b/bucket/kubectl.json
@@ -5,27 +5,27 @@
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://storage.googleapis.com/kubernetes-release/release/v1.21.1/kubernetes-client-windows-amd64.tar.gz",
+            "url": "https://dl.k8s.io/release/v1.21.1/kubernetes-client-windows-amd64.tar.gz",
             "hash": "4e013fa5563d03a5e6c7dcbe56dabcc82c866bac28ec268500dfaf8a8fcdfb7c"
         },
         "32bit": {
-            "url": "https://storage.googleapis.com/kubernetes-release/release/v1.21.1/kubernetes-client-windows-386.tar.gz",
+            "url": "https://dl.k8s.io/release/v1.21.1/kubernetes-client-windows-386.tar.gz",
             "hash": "80894bd11dd9c2df9367670c0a10129d177c3d8683bf6572bbaedd1b45914586"
         }
     },
     "extract_dir": "kubernetes\\client",
     "bin": "bin\\kubectl.exe",
     "checkver": {
-        "url": "https://storage.googleapis.com/kubernetes-release/release/stable.txt",
+        "url": "https://dl.k8s.io/release/stable.txt",
         "regex": "v([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://storage.googleapis.com/kubernetes-release/release/v$version/kubernetes-client-windows-amd64.tar.gz"
+                "url": "https://dl.k8s.io/release/v$version/kubernetes-client-windows-amd64.tar.gz"
             },
             "32bit": {
-                "url": "https://storage.googleapis.com/kubernetes-release/release/v$version/kubernetes-client-windows-386.tar.gz"
+                "url": "https://dl.k8s.io/release/v$version/kubernetes-client-windows-386.tar.gz"
             }
         },
         "hash": {


### PR DESCRIPTION
## Description
The original url path, on google storage, seems to often create false positives when evaluated with virustotal. 

## Related Tickets & Documents

## Did you

### Check Hashes?
<!-- using: `.\bin\checkhashes.ps1 "%%manifest%%.json" -Update` -->

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Check Url?
<!-- Using: `.\bin\checkurls.ps1 "%%manifest%%.json"` -->

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Check the last version?
<!-- Using: `.\bin\checkver.ps1 "%%manifest%%.json" -Update` -->

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added a description in the manifest?
<!-- Using: `.\bin\describe.ps1 "%%manifest%%.json"` -->

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Beautified the json manifest format?
<!-- Using: `.\bin\formatjson.ps1 "%%manifest%%.json"`-->

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added some notes in the manifest?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added/Needed any dependencies?

- [ ] 👍 yes
- [ ] 🙋 yes, but I need help
- [x] 🙅 no, because they aren't needed

## Added/Needed any pre-installation steps to perform?

- [ ] 👍 yes
- [ ] 🙋 yes, but I need help
- [x] 🙅 no, because they aren't needed

## Added/Needed any post-installation steps to perform?

- [ ] 👍 yes
- [ ] 🙋 yes, but I need help
- [x] 🙅 no, because they aren't needed

## [optional] What gif/emoji best describes this PR or how it makes you feel?

:construction_worker:
