### PR TITLE
dotnet-sdk-sts: Add version 7.0.100

### DIFF
--- a/bucket/dotnet-sdk-sts.json
+++ b/bucket/dotnet-sdk-sts.json
@@ -1,0 +1,57 @@
+{
+    "version": "7.0.100",
+    "description": ".NET is a free, cross-platform, open source developer platform for building many different types of applications.",
+    "homepage": "https://www.microsoft.com/net/",
+    "license": "MIT",
+    "suggest": {
+        "Visual C++ Redistributable": "vcredist"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0.100/dotnet-sdk-7.0.100-win-x64.zip",
+            "hash": "sha512:e77fa3501f6945dd5730dbcec7632f070314717c6abfa95f95e13db53bfd55d2f46faa45809f796535749c8d98251828a4b4ab4d5ceb3ee1daa5262c6907f906"
+        },
+        "arm64": {
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0.100/dotnet-sdk-7.0.100-win-arm64.zip",
+            "hash": "sha512:62ecf2bb2466da663117563b8cc8059fc6dc79f3180012039692e693a14bc98daeb7218f83180e8bfa15f1aa419b780af4424b265a9f231bcb3f6feffc9ed921"
+        },
+        "32bit": {
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0.100/dotnet-sdk-7.0.100-win-x86.zip",
+            "hash": "sha512:ae586c292334c51eebf5f0e6bcaa7e3a56a06a37d24278bd132f2df62702f79fab3b4a478c2b25a2920e40d34b3b79d89cb1c831eb1d94927f0652842d47a5a2"
+        }
+    },
+    "bin": "dotnet.exe",
+    "env_add_path": [
+        ".",
+        "\\sdk\\7.0.100"
+    ],
+    "env_set": {
+        "DOTNET_ROOT": "$dir",
+        "DOTNET_CLI_TELEMETRY_OPTOUT": true,
+        "MSBuildSDKsPath": "$dir\\sdk\\$version\\Sdks"
+    },
+    "checkver": {
+        "url": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json",
+        "regex": "(?s)(?<rtv>[\\d.]+)[^\\d]*?([\\d.]+)[^\\d]*?(?:sts)([\\w\",\\s\\-\\:]+)(?:active)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$version/dotnet-sdk-$version-win-x64.zip"
+            },
+            "arm64": {
+                "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$version/dotnet-sdk-$version-win-arm64.zip"
+            },
+            "32bit": {
+                "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$version/dotnet-sdk-$version-win-x86.zip"
+            }
+        },
+        "hash": {
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/$matchRtv-sha.txt"
+        },
+        "env_add_path": [
+            ".",
+            "\\sdk\\$version"
+        ]
+    }
+}


### PR DESCRIPTION
## What type of Apps related PR is this? (check all applicable)
- [x] ✨ Add Manifest
- [ ] ♻️ Refactor
- [ ] 🐛 Bug Fix
- [x] 👷 Optimization
- [ ] 🚩 Other

## Description
dotnet-sdk-sts is for the "Standard Term Support" version of the dotnet SDK. It is installed side-by-side and "override" the DOTNET_ROOT variable to be able to use it directly. We can always switch easily between the dotnet-sdk (LTS) and this one by using the `scoop reset dotnet-sdk` or `scoop reset dotnet-sdk-sts`.

The use of `dotnet --version` can also be helpful to know which one is actually active

## Related Tickets & Documents
None

## [optional] What gif/emoji best describes this PR or how it makes you feel?
:tada: :dancers: :sparkles: :zap:

## Did you verify the followings

### Add/Modify a description in the manifest?
- [x] 👍 yes
- [ ] 🙋 yes, but I need help
- [ ] 🙅 no, because they aren't needed

### Check URLs?
- [x] 👍 yes
- [ ] 🙋 yes, but I need help
- [ ] 🙅 no, because they aren't needed

### Update to the latest version?
- [x] 👍 yes
- [ ] 🙋 yes, but I need help
- [ ] 🙅 no, because they aren't needed

### Update Hashes?
- [x] 👍 yes
- [ ] 🙋 yes, but I need help
- [ ] 🙅 no, because they aren't needed

### Format the json manifest?
- [x] 👍 yes
- [ ] 🙋 yes, but I need help
- [ ] 🙅 no, because they aren't needed

## Did you identify extra steps

### Notes in the manifest?
- [ ] 👍 yes
- [ ] 🙋 yes, but I need help
- [x] 🙅 no, because they aren't needed

### Application Dependencies?
- [ ] 👍 yes
- [ ] 🙋 yes, but I need help
- [x] 🙅 no, because they aren't needed

### Application Suggestions?
- [x] 👍 yes
- [ ] 🙋 yes, but I need help
- [ ] 🙅 no, because they aren't needed

### Pre-installation steps to perform?
- [ ] 👍 yes
- [ ] 🙋 yes, but I need help
- [x] 🙅 no, because they aren't needed

### Post-installation steps to perform?
- [ ] 👍 yes
- [ ] 🙋 yes, but I need help
- [x] 🙅 no, because they aren't needed

### File persistence to perform?
- [ ] 👍 yes
- [ ] 🙋 yes, but I need help
- [x] 🙅 no, because they aren't needed

### Other ?
- [x] :rotating_light: Change the Environment variable required (this will impact the dotnet-sdk version soon)
- [x] Added the arm64
- [x] Changes the regex (from the lts version) to obtain the version so it wil remove risks of getting any "sts" version (aka "eol", "maintenance", etc.)