### PR TITLE
dotnet-sdk* : Update .NET SDKs manifests to share sdks and runtimes

### DIFF
--- a/bucket/dotnet-sdk-preview.json
+++ b/bucket/dotnet-sdk-preview.json
@@ -7,13 +7,13 @@
         "You can switch to the required dotnet SDK version at any time.",
         "To do so, use the 'scoop reset' command with similar examples as shown below:",
         "# Reseting to the latest .NET SDK (LTS) version",
-        "'scoop reset dotnet-sdk-preview'",
+        "'scoop reset dotnet-sdk'",
         "# Reseting to a specific .NET SDK version",
         "'scoop reset dotnet-sdk-preview@10.0.100-preview.1.25120.13'",
         "# Reseting to the current .NET SDK (STS) version",
         "'scoop reset dotnet-sdk-sts'",
-        "# Resetting to the latest .NET SDK version",
-        "'scoop reset dotnet-sdk'"
+        "# Resetting to the latest .NET SDK (Preview) version",
+        "'scoop reset dotnet-sdk-preview'"
     ],
     "suggest": {
         "Visual C++ Redistributable": "vcredist",
@@ -46,6 +46,51 @@
         "DOTNET_CLI_TELEMETRY_OPTOUT": true,
         "MSBuildSDKsPath": "$dir\\sdk\\$version\\Sdks"
     },
+    "pre_install": [
+        "# Move .NET SDK files only if the shared persist directory already exists",
+        "Write-Host",
+        "$sharedPersist = Join-Path (Resolve-Path \"$persist_dir\\..\").Path \"dotnet\"",
+        "Write-Host The \"$sharedPersist\" folder will be used to shared all dotnet-sdk* release",
+        "Write-Host \"   to add support to sdks and runtimes of dotnet installed by scoop\"",
+        "if (Test-Path \"$sharedPersist\") {",
+        "   (\"sdk\",\"sdk-manifests\",\"shared\") | ForEach-Object {",
+        "       $src = Join-Path $dir $_",
+        "       $dst = Join-Path $sharedPersist $_",
+        "       Write-Host \"Sharing the $_ folder into $sharedPersist\"",
+        "       New-Item -ItemType Directory -Path $dst -Force | Out-Null",
+        "       Copy-Item -Path (Join-Path $src \"*\") -Destination $dst -Recurse -Force",
+        "       Remove-Item -Path $src -Recurse -Force",
+        "   }",
+        "} else {",
+        "   Write-Host \"$sharedPersist\" does not exist. It will be created...",
+        "}"
+    ],
+    "pre_uninstall": [
+        "$major = ($version -split '\\.')[0]",
+        "$sharedRoot = Join-Path (Resolve-Path \"$persist_dir\\..\").Path \"dotnet\"",
+        "if (Test-Path $sharedRoot) {",
+        "   Write-Host Removing any shared dotnet-sdk files for version $major.*",
+        "   (\"sdk\",\"sdk-manifests\",\"shared\") | ForEach-Object {",
+        "      $root = Join-Path $sharedRoot $_",
+        "      if (Test-Path $root) {",
+        "         if ($_ -eq 'shared') {",
+        "            Get-ChildItem -LiteralPath $root -Directory -Force -ErrorAction SilentlyContinue | ForEach-Object {",
+        "               Get-ChildItem -LiteralPath $_.FullName -Directory -Force -ErrorAction SilentlyContinue | Where-Object { $_.Name -like \"$major.*\" } | ForEach-Object {",
+        "                  Remove-Item -LiteralPath $_.FullName -Recurse -Force -ErrorAction SilentlyContinue",
+        "               }",
+        "            }",
+        "         } else {",
+        "            Get-ChildItem -LiteralPath $root -Directory -Force -ErrorAction SilentlyContinue | Where-Object { $_.Name -like \"$major.*\" } | ForEach-Object { Remove-Item -LiteralPath $_.FullName -Recurse -Force -ErrorAction SilentlyContinue }",
+        "         }",
+        "      }",
+        "   }",
+        "}"
+    ],
+    "persist": [
+        ["sdk", "../dotnet/sdk"],
+        ["sdk-manifests", "../dotnet/sdk-manifests"],
+        ["shared", "../dotnet/shared"]
+    ],
     "checkver": {
         "url": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json",
         "jsonpath": "$.releases-index[?(@.release-type == 'lts' && @.support-phase == 'preview')].latest-sdk"

--- a/bucket/dotnet-sdk-sts.json
+++ b/bucket/dotnet-sdk-sts.json
@@ -3,8 +3,22 @@
     "description": ".NET is a free, cross-platform, open source developer platform for building many different types of applications.",
     "homepage": "https://www.microsoft.com/net/",
     "license": "MIT",
+    "notes": [
+        "You can switch to the required dotnet SDK version at any time.",
+        "To do so, use the 'scoop reset' command with similar examples as shown below:",
+        "# Reseting to the latest .NET SDK (LTS) version",
+        "'scoop reset dotnet-sdk'",
+        "# Reseting to a specific .NET SDK version",
+        "'scoop reset dotnet-sdk-sts@9.0.100'",
+        "# Reseting to the current .NET SDK (STS) version",
+        "'scoop reset dotnet-sdk-sts'",
+        "# Resetting to the latest .NET SDK (Preview) version",
+        "'scoop reset dotnet-sdk-preview'"
+    ],
     "suggest": {
-        "Visual C++ Redistributable": "vcredist"
+        "Visual C++ Redistributable": "vcredist",
+        ".NET SDK (LTS)": "dotnet-sdk",
+        ".NET SDK (LTS - preview)": "dotnet-sdk-preview"
     },
     "architecture": {
         "64bit": {
@@ -32,6 +46,51 @@
         "DOTNET_CLI_TELEMETRY_OPTOUT": true,
         "MSBuildSDKsPath": "$dir\\sdk\\$version\\Sdks"
     },
+    "pre_install": [
+        "# Move .NET SDK files only if the shared persist directory already exists",
+        "Write-Host",
+        "$sharedPersist = Join-Path (Resolve-Path \"$persist_dir\\..\").Path \"dotnet\"",
+        "Write-Host The \"$sharedPersist\" folder will be used to shared all dotnet-sdk* release",
+        "Write-Host \"   to add support to sdks and runtimes of dotnet installed by scoop\"",
+        "if (Test-Path \"$sharedPersist\") {",
+        "   (\"sdk\",\"sdk-manifests\",\"shared\") | ForEach-Object {",
+        "       $src = Join-Path $dir $_",
+        "       $dst = Join-Path $sharedPersist $_",
+        "       Write-Host \"Sharing the $_ folder into $sharedPersist\"",
+        "       New-Item -ItemType Directory -Path $dst -Force | Out-Null",
+        "       Copy-Item -Path (Join-Path $src \"*\") -Destination $dst -Recurse -Force",
+        "       Remove-Item -Path $src -Recurse -Force",
+        "   }",
+        "} else {",
+        "   Write-Host \"$sharedPersist\" does not exist. It will be created...",
+        "}"
+    ],
+    "pre_uninstall": [
+        "$major = ($version -split '\\.')[0]",
+        "$sharedRoot = Join-Path (Resolve-Path \"$persist_dir\\..\").Path \"dotnet\"",
+        "if (Test-Path $sharedRoot) {",
+        "   Write-Host Removing any shared dotnet-sdk files for version $major.*",
+        "   (\"sdk\",\"sdk-manifests\",\"shared\") | ForEach-Object {",
+        "      $root = Join-Path $sharedRoot $_",
+        "      if (Test-Path $root) {",
+        "         if ($_ -eq 'shared') {",
+        "            Get-ChildItem -LiteralPath $root -Directory -Force -ErrorAction SilentlyContinue | ForEach-Object {",
+        "               Get-ChildItem -LiteralPath $_.FullName -Directory -Force -ErrorAction SilentlyContinue | Where-Object { $_.Name -like \"$major.*\" } | ForEach-Object {",
+        "                  Remove-Item -LiteralPath $_.FullName -Recurse -Force -ErrorAction SilentlyContinue",
+        "               }",
+        "            }",
+        "         } else {",
+        "            Get-ChildItem -LiteralPath $root -Directory -Force -ErrorAction SilentlyContinue | Where-Object { $_.Name -like \"$major.*\" } | ForEach-Object { Remove-Item -LiteralPath $_.FullName -Recurse -Force -ErrorAction SilentlyContinue }",
+        "         }",
+        "      }",
+        "   }",
+        "}"
+    ],
+    "persist": [
+        ["sdk", "../dotnet/sdk"],
+        ["sdk-manifests", "../dotnet/sdk-manifests"],
+        ["shared", "../dotnet/shared"]
+    ],
     "checkver": {
         "url": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json",
         "jsonpath": "$.releases-index[?(@.release-type == 'sts' && @.support-phase != 'eol')].latest-sdk"

--- a/bucket/dotnet-sdk.json
+++ b/bucket/dotnet-sdk.json
@@ -12,14 +12,13 @@
         "'scoop reset dotnet-sdk@8.0.100'",
         "# Reseting to the current .NET SDK (STS) version",
         "'scoop reset dotnet-sdk-sts'",
-        "# Resetting to the latest .NET6 SDK version",
-        "'scoop reset dotnet6-sdk'"
+        "# Resetting to the latest .NET SDK (Preview) version",
+        "'scoop reset dotnet-sdk-preview'"
     ],
     "suggest": {
         "Visual C++ Redistributable": "vcredist",
-        ".NET SDK (LTS - preview)": "dotnet-sdk-preview",
         ".NET SDK (STS)": "dotnet-sdk-sts",
-        ".NET 6 SDK": "dotnet6-sdk"
+        ".NET SDK (LTS - preview)": "dotnet-sdk-preview"
     },
     "architecture": {
         "64bit": {
@@ -47,6 +46,51 @@
         "DOTNET_CLI_TELEMETRY_OPTOUT": true,
         "MSBuildSDKsPath": "$dir\\sdk\\$version\\Sdks"
     },
+    "pre_install": [
+        "# Move .NET SDK files only if the shared persist directory already exists",
+        "Write-Host",
+        "$sharedPersist = Join-Path (Resolve-Path \"$persist_dir\\..\").Path \"dotnet\"",
+        "Write-Host The \"$sharedPersist\" folder will be used to shared all dotnet-sdk* release",
+        "Write-Host \"   to add support to sdks and runtimes of dotnet installed by scoop\"",
+        "if (Test-Path \"$sharedPersist\") {",
+        "   (\"sdk\",\"sdk-manifests\",\"shared\") | ForEach-Object {",
+        "       $src = Join-Path $dir $_",
+        "       $dst = Join-Path $sharedPersist $_",
+        "       Write-Host \"Sharing the $_ folder into $sharedPersist\"",
+        "       New-Item -ItemType Directory -Path $dst -Force | Out-Null",
+        "       Copy-Item -Path (Join-Path $src \"*\") -Destination $dst -Recurse -Force",
+        "       Remove-Item -Path $src -Recurse -Force",
+        "   }",
+        "} else {",
+        "   Write-Host \"$sharedPersist\" does not exist. It will be created...",
+        "}"
+    ],
+    "pre_uninstall": [
+        "$major = ($version -split '\\.')[0]",
+        "$sharedRoot = Join-Path (Resolve-Path \"$persist_dir\\..\").Path \"dotnet\"",
+        "if (Test-Path $sharedRoot) {",
+        "   Write-Host Removing any shared dotnet-sdk files for version $major.*",
+        "   (\"sdk\",\"sdk-manifests\",\"shared\") | ForEach-Object {",
+        "      $root = Join-Path $sharedRoot $_",
+        "      if (Test-Path $root) {",
+        "         if ($_ -eq 'shared') {",
+        "            Get-ChildItem -LiteralPath $root -Directory -Force -ErrorAction SilentlyContinue | ForEach-Object {",
+        "               Get-ChildItem -LiteralPath $_.FullName -Directory -Force -ErrorAction SilentlyContinue | Where-Object { $_.Name -like \"$major.*\" } | ForEach-Object {",
+        "                  Remove-Item -LiteralPath $_.FullName -Recurse -Force -ErrorAction SilentlyContinue",
+        "               }",
+        "            }",
+        "         } else {",
+        "            Get-ChildItem -LiteralPath $root -Directory -Force -ErrorAction SilentlyContinue | Where-Object { $_.Name -like \"$major.*\" } | ForEach-Object { Remove-Item -LiteralPath $_.FullName -Recurse -Force -ErrorAction SilentlyContinue }",
+        "         }",
+        "      }",
+        "   }",
+        "}"
+    ],
+    "persist": [
+        ["sdk", "../dotnet/sdk"],
+        ["sdk-manifests", "../dotnet/sdk-manifests"],
+        ["shared", "../dotnet/shared"]
+    ],
     "checkver": {
         "url": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json",
         "jsonpath": "$.releases-index[?(@.release-type == 'lts' && @.support-phase == 'active')].latest-sdk"


### PR DESCRIPTION
## What type of Apps related PR is this? (check all applicable)
- [ ] ✨ Add Manifest
- [x] ♻️ Refactor
- [ ] 🐛 Bug Fix
- [x] 👷 Optimization
- [x] 🚩 Other
## [optional] What gif/emoji best describes this PR or how it makes you feel?
:dizzy: :building_construction: :airplane: :package: :egg:
## Description
This is to add a persist storage to perform a similar install process as the official one which install all SDKs and Runtimes under the same folders. This help enhance the dotnet experience while installing the SDKs (lts, sts or preview) to coexists. It is for example really useful when tools like VSCode (and some extensions) uses dotnet-sdk-sts (aka 9) other extensions using the dotnet-sdk-preview (aka 10) while wanting to debug a csproj build to run on the dotnet-sdk (aka 8).
It also fixes some minor details in manifests' notes
## Related Tickets & Documents
- The pre_install is required to move the sdks, into the common shared folder if it's present. Otherwise, it follow the default scoop process for the persistence
- The pre_uninstall is required to remove the sdks and runtimes of a specific version (lts, sts or preview) from the persist folder. Since the sdks and runtimes dont have the same version (by design), the major version is used to identify the folders to be removed. If we don't remove theses folders and files from the persist storage, it could create potential issues with the "dotnet.exe" since part of the sdk would have been removed while other still present.
- Be advise : It may feel as a hack since persist folder should be to persist data without removing it during a uninstall. So yeah, it's a work around for dotnet to help multiple sdks versions to coexists
## [optional] What gif/emoji best describes this PR or how it makes you feel?
:dizzy: :building_construction: :airplane: :package: :egg:
## Did you verify the followings
### Add/Modify a description in the manifest?
- [x] 👍 yes
- [ ] 🙋 yes, but I need help
- [ ] 🙅 no, because they aren't needed
### Check URLs?
- [x] 👍 yes
- [ ] 🙋 yes, but I need help
- [ ] 🙅 no, because they aren't needed
### Update to the latest version?
- [x] 👍 yes
- [ ] 🙋 yes, but I need help
- [ ] 🙅 no, because they aren't needed
### Update Hashes?
- [x] 👍 yes
- [ ] 🙋 yes, but I need help
- [ ] 🙅 no, because they aren't needed
### Format the json manifest?
- [x] 👍 yes
- [ ] 🙋 yes, but I need help
- [ ] 🙅 no, because they aren't needed
## Did you identify extra steps
### Notes in the manifest?
- [x] 👍 yes
- [ ] 🙋 yes, but I need help
- [ ] 🙅 no, because they aren't needed
### Application Dependencies?
- [ ] 👍 yes
- [ ] 🙋 yes, but I need help
- [x] 🙅 no, because they aren't needed
### Application Suggestions?
- [x] 👍 yes
- [ ] 🙋 yes, but I need help
- [ ] 🙅 no, because they aren't needed
### Pre-installation steps to perform?
- [x] 👍 yes
- [ ] 🙋 yes, but I need help
- [ ] 🙅 no, because they aren't needed
### Post-installation steps to perform?
- [ ] 👍 yes
- [ ] 🙋 yes, but I need help
- [x] 🙅 no, because they aren't needed
### Pre-uninstallation steps to perform?
- [x] 👍 yes
- [ ] 🙋 yes, but I need help
- [ ] 🙅 no, because they aren't needed
### Post-uninstallation steps to perform?
- [ ] 👍 yes
- [ ] 🙋 yes, but I need help
- [x] 🙅 no, because they aren't needed
### File persistence to perform?
- [x] 👍 yes
- [ ] 🙋 yes, but I need help
- [ ] 🙅 no, because they aren't needed
