### PR TITLE
nodejs: Update to version 25.1.0, drop 32bit

### DIFF
--- a/bucket/nodejs.json
+++ b/bucket/nodejs.json
@@ -1,23 +1,18 @@
 {
-    "version": "22.9.0",
+    "version": "25.1.0",
     "description": "An asynchronous event driven JavaScript runtime designed to build scalable network applications.",
     "homepage": "https://nodejs.org",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://nodejs.org/dist/v22.9.0/node-v22.9.0-win-x64.7z",
-            "hash": "805d4f842b2f85907fc28d1d631971bac5c1df691d7040cfa5e46d02534f98df",
-            "extract_dir": "node-v22.9.0-win-x64"
-        },
-        "32bit": {
-            "url": "https://nodejs.org/dist/v22.9.0/node-v22.9.0-win-x86.7z",
-            "hash": "3a6b798464794a0ac2452cf51e55df6f60f09598f724dd3eb890d64d99d81e5b",
-            "extract_dir": "node-v22.9.0-win-x86"
+            "url": "https://nodejs.org/dist/v25.1.0/node-v25.1.0-win-x64.7z",
+            "hash": "714ba455c0d4a6b6956151ab56ef5fd1730baa6e0835f024d86767ef8b386aee",
+            "extract_dir": "node-v25.1.0-win-x64"
         },
         "arm64": {
-            "url": "https://nodejs.org/dist/v22.9.0/node-v22.9.0-win-arm64.7z",
-            "hash": "7a0a0a3998d989fe117f358e17ae0542ba264d2ae5c5681fc9d9ce8a666ce7b2",
-            "extract_dir": "node-v22.9.0-win-arm64"
+            "url": "https://nodejs.org/dist/v25.1.0/node-v25.1.0-win-arm64.7z",
+            "hash": "6c4d7d10c7344c6c85890d0057e9d0215d3fd967aae7f80db4d45248db158e76",
+            "extract_dir": "node-v25.1.0-win-arm64"
         }
     },
     "persist": [
@@ -33,18 +28,15 @@
         "Set-Content -Value \"prefix=$persist_dir\\bin`ncache=$persist_dir\\cache\" -Path \"$dir\\node_modules\\npm\\npmrc\""
     ],
     "checkver": {
-        "url": "https://nodejs.org/dist/latest/",
-        "regex": "node-v([\\d.]+)-win-x64\\.7z"
+        "url": "https://nodejs.org/dist/index.json",
+        "jsonpath": "$[0].version",
+        "regex": "v([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": "https://nodejs.org/dist/v$version/node-v$version-win-x64.7z",
                 "extract_dir": "node-v$version-win-x64"
-            },
-            "32bit": {
-                "url": "https://nodejs.org/dist/v$version/node-v$version-win-x86.7z",
-                "extract_dir": "node-v$version-win-x86"
             },
             "arm64": {
                 "url": "https://nodejs.org/dist/v$version/node-v$version-win-arm64.7z",


### PR DESCRIPTION
## What type of Apps related PR is this? (check all applicable)
- [ ] ✨ Add Manifest
- [ ] ♻️ Refactor
- [x] 🐛 Bug Fix
- [ ] 👷 Optimization
- [ ] 🚩 Other
## Description
Update the NodeJS to 25.1.0 and removing support for 32bit
## Related Tickets & Documents
None
## [optional] What gif/emoji best describes this PR or how it makes you feel?
:alien:
## Did you verify the followings
### Add/Modify a description in the manifest?
- [x] 👍 yes
- [ ] 🙋 yes, but I need help
- [ ] 🙅 no, because they aren't needed
### Check URLs?
- [x] 👍 yes
- [ ] 🙋 yes, but I need help
- [ ] 🙅 no, because they aren't needed
### Update to the latest version?
- [x] 👍 yes
- [ ] 🙋 yes, but I need help
- [ ] 🙅 no, because they aren't needed
### Update Hashes?
- [x] 👍 yes
- [ ] 🙋 yes, but I need help
- [ ] 🙅 no, because they aren't needed
### Format the json manifest?
- [x] 👍 yes
- [ ] 🙋 yes, but I need help
- [ ] 🙅 no, because they aren't needed
## Did you identify extra steps
### Notes in the manifest?
- [ ] 👍 yes
- [ ] 🙋 yes, but I need help
- [x] 🙅 no, because they aren't needed
### Application Dependencies?
- [ ] 👍 yes
- [ ] 🙋 yes, but I need help
- [x] 🙅 no, because they aren't needed
### Application Suggestions?
- [ ] 👍 yes
- [ ] 🙋 yes, but I need help
- [x] 🙅 no, because they aren't needed
### Pre-installation steps to perform?
- [ ] 👍 yes
- [ ] 🙋 yes, but I need help
- [x] 🙅 no, because they aren't needed
### Post-installation steps to perform?
- [x] 👍 yes
- [ ] 🙋 yes, but I need help
- [ ] 🙅 no, because they aren't needed
### File persistence to perform?
- [x] 👍 yes
- [ ] 🙋 yes, but I need help
- [ ] 🙅 no, because they aren't needed
